### PR TITLE
Ignore route API in none OCP clusters

### DIFF
--- a/controllers/reconcilers/grafana/ingress_reconciler.go
+++ b/controllers/reconcilers/grafana/ingress_reconciler.go
@@ -3,6 +3,7 @@ package grafana
 import (
 	"context"
 	"fmt"
+
 	"github.com/grafana-operator/grafana-operator-experimental/api/v1beta1"
 	"github.com/grafana-operator/grafana-operator-experimental/controllers/model"
 	"github.com/grafana-operator/grafana-operator-experimental/controllers/reconcilers"
@@ -105,6 +106,9 @@ func (r *IngressReconciler) isOpenShift() (bool, error) {
 	apiGroupVersion := routev1.SchemeGroupVersion.String()
 
 	apiList, err := r.discovery.ServerResourcesForGroupVersion(apiGroupVersion)
+	if apiList == nil {
+		return false, nil
+	}
 	if err != nil {
 		return false, err
 	}


### PR DESCRIPTION
I'm not to happy about this solution, it's rather ugly...
If we get an error we will never come to the error stage since the return value will always be nil.

Might be some better way of checking if routes is available or not.
You probably have a better idea then I do but this works at least. I haven't verified on OCP but I think we should be okay.

Solves: https://github.com/pb82/grafana-operator-experimental/issues/2
